### PR TITLE
use smaller docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,20 @@
-FROM continuumio/miniconda3:23.9.0-0
+FROM python:3.14.0a2-slim
 LABEL maintainer="Xiaoli.Zhang@rr-research.no"
-RUN conda update -n base -c defaults conda \
-    && conda install xlrd -c conda-forge \
-    && conda install xlutils -c conda-forge \
-    && conda install python-pptx -c conda-forge \
-    && conda install python-docx -c conda-forge
-RUN mkdir -p /pronto
+# install dependencies
+COPY requirements.txt .
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential=12.9 \
+        libjpeg-dev=1:2.1.5-2 \
+        libxml2=2.9.14+dfsg-1.3~deb12u1 \
+        libxslt1-dev=1.1.35-1 \
+        zlib1g-dev=1:1.2.13.dfsg-1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && pip install -r requirements.txt \
+    && rm requirements.txt
+# copy over config, template and script
 COPY Config /pronto/Config
 COPY In /pronto/In
-COPY Out /pronto/Out
 COPY Script /pronto/Script
-COPY Testing_data /pronto/Testing_data
+COPY pronto /pronto/Script/pronto

--- a/Script/PRONTO.py
+++ b/Script/PRONTO.py
@@ -829,8 +829,7 @@ def update_ppt_variant_summary_table(data_nrows,DNA_sampleID,RNA_sampleID,TMB_DR
 					splicing = "splicing: None reported"
 				else:
 					splicing = "splicing: " + splice_variants_str.split('(')[0]
-					pattern_splicing = "\|(.*?)\("
-					splicing_end = re.findall(pattern_splicing, splice_variants_str)
+					splicing_end = re.findall('\\|(.*?)\\(', splice_variants_str)
 					if(splicing_end):
 						for splice in splicing_end:
 							splicing += ',' + splice
@@ -839,8 +838,7 @@ def update_ppt_variant_summary_table(data_nrows,DNA_sampleID,RNA_sampleID,TMB_DR
 					fusion = "fusion: None reported"
 				else:
 					fusion = "fusion: " + gene_fusion_str.split('(')[0]
-					pattern_fusion = "\|(.*?)\("
-					fusion_end = re.findall(pattern_fusion, gene_fusion_str)
+					fusion_end = re.findall('\\|(.*?)\\(', gene_fusion_str)
 					if(fusion_end):
 						for fus in fusion_end:
 							fusion += ';' + fus
@@ -1198,7 +1196,7 @@ def main(argv):
 		elif opt in ("-c", "--clinicalFile"):
 			update_clinical_file = True
 	runID_DNA = runID
-	DNA_sampleID_format = "IP\w\d\d\d\d-D(\d|X)(\d|X)-\w(\d|X)(\d|X)-\w(\d|X)(\d|X)"
+	DNA_sampleID_format = '^IP[A-Z]\\d{4}-D(\\d|X){2}-[A-z](\\d|X){2}-[A-z](\\d|X){2}'
 
 	base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 	config_file = base_dir + "/Config/configure_PRONTO.ini"


### PR DESCRIPTION
Hey again!

I realized the docker image does not contain the module so I added it. I also used a smaller image which allows us to reduce the size of the final image by more than half. In addition I omit adding test data (which should not be included in the image) and the output directory (which I thought should just be an empty dir?). I also use pip to install stuff now as conda is not available. Conda is quite a big dependency which I think is unnecessary for a container which only runs PRONTO.

I was also thinking about adding pronto to the path to allow us to call it from anywhere but this could be done in a later PR.