### PR TITLE
chore: update dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential=12.9 \
         libjpeg-dev=1:2.1.5-2 \
-        libxml2=2.9.14+dfsg-1.3~deb12u1 \
-        libxslt1-dev=1.1.35-1+deb12u1 \
-        poppler-utils=22.12.0-2+b1 \
+        libxml2=2.9.14+dfsg-1.3~deb12u2 \
+        libxslt1-dev=1.1.35-1+deb12u2 \
+        poppler-utils=22.12.0-2+deb12u1 \
         zlib1g-dev=1:1.2.13.dfsg-1 \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \


### PR DESCRIPTION
there were some outdated dependencies in the Dockerfile and it could not build. I fixed them and tried building locally which worked fine. I think this will allow us to get a new image ready.